### PR TITLE
I started using ColorColumn and figured out that bright red is not ideal

### DIFF
--- a/colors/inkpot.vim
+++ b/colors/inkpot.vim
@@ -142,6 +142,7 @@ if has("gui_running")
     endif
     if v:version >= 703
         hi Conceal      gui=NONE      guifg=#c080d0   guibg=NONE
+        hi ColorColumn  gui=NONE                      guibg=#2e2e2e
     endif
 else
     if ! g:inkpot_black_background
@@ -216,6 +217,7 @@ else
     endif
     if v:version >= 703
         exec "hi Conceal      cterm=NONE      ctermfg=" . <SID>X(55) . " ctermbg=" . "NONE"
+        exec "hi ColorColumn  cterm=NONE      ctermbg=" . <SID>X(81)
     endif
 endif
 


### PR DESCRIPTION
Hey,

inkpot is missing the ColorColumn highlight, so I added it. It defaults to the normal highlight color which is bright red and therefore meant to be annoying, where ColorColumn is just a friendly reminder, so I changed it to a more pleasant dark grey.

Please merge, and thanks again for this awesome color scheme.
